### PR TITLE
Increased minimum CentOS version to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Requirements
 
         * CentOS
 
-            * 7
+            * 8
 
         * Fedora
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 8
     - name: Fedora
       versions:
         - 31

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_sdkman_centos
-    image: centos:7
+    image: centos:8
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
The version of Zsh that comes with CentOS 7 isn't recent enough for the tab-completion to work.